### PR TITLE
feat: add support for gnome-epub-thumbnailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 ## Requirements
 
 - [yazi](https://github.com/sxyazi/yazi)
-- An epub-thumbnailer:
+- At least one of the following epub-thumbnailer command line tools:
   - [epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer), or
   - [gnome-epub-thumbnailer](https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer)
+    (available as `gnome-epub-thumbnailer` package in Ubuntu and arch)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
 git clone https://github.com/kirasok/epub-preview.yazi.git ~/.config/yazi/plugins/epub-preview.yazi
 ```
 
+or with [`ya-pack`](https://yazi-rs.github.io/docs/cli/#package-manager)
+```sh
+ya pack -a kirasok/epub-preview
+```
+
 ## Usage
 
 Add this to your `yazi.toml`:
@@ -32,3 +37,21 @@ Add this to your `yazi.toml`:
 mime = "application/epub+zip"
 run = "epub-preview"
 ```
+
+## Troubleshooting when no preview is shown
+
+- Make sure that the epub-thumbnailer is installed and available in your PATH. A command like this should work:
+
+  ```bash
+  gnome-epub-thumbnailer [something.epub] [output.png]
+  ```
+
+- Check your `yazi.toml`: If there is another previewer with zip file handling, epub-preview might be overwritten, e.g.: with the definition blow, `ouch` will run, not `epub-preview`:
+
+  ```toml
+  [[plugin.prepend_previewers]]
+  mime = "application/*zip" 
+  run = "ouch" 
+  ```
+
+- Check Yazi log file (see [yazi.rs](https://yazi-rs.github.io/docs/plugins/overview/#logging) where to find it) 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 ## Requirements
 
 - [yazi](https://github.com/sxyazi/yazi)
-- [epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer)
+- An epub-thumbnailer:
+  - [epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer), or
+  - [gnome-epub-thumbnailer](https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer)
 
 ## Installation
 

--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,7 @@ end
 function M:seek() end
 
 function M:preload()
+	ya.err("huhu")
 	local cache = ya.file_cache(self)
 	if not cache or fs.cha(cache) then
 		return 1
@@ -22,6 +23,7 @@ function M:preload()
 
 	local size = math.min(PREVIEW.max_width, PREVIEW.max_height)
 
+	-- First try to use `epub-thumbnailer` command
 	local child, code = Command("epub-thumbnailer"):args({
 		tostring(self.file.url),
 		tostring(cache),
@@ -29,8 +31,16 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("spawn `epub-thumbnailer` command returns " .. tostring(code))
-		return 0
+		-- If `epub-thumbnailer` command is not available, try to use `gnome-epub-thumbnailer` command
+		child, code = Command("gnome-epub-thumbnailer"):args({
+			tostring(self.file.url),
+			tostring(cache),
+			-- gnome-epub-thumbnailer does not need a size
+		}):spawn()
+		if not child then
+			ya.err("spawn `gnome-epub-thumbnailer` command returns " .. tostring(code))
+			return 0
+		end
 	end
 
 	local status = child:wait()


### PR DESCRIPTION
- Modified init.lua to try gnome-epub-thumbnailer if epub-thumbnailer
  is not available.
- Updated README.md to include gnome-epub-thumbnailer as an alternative
  to epub-thumbnailer.

Background: GNOME-Users face the same need for thumbnails in their file browser.
It might be easier for them to install epub thumbnailer or have it already:
[omgubuntu.co.uk](https://www.omgubuntu.co.uk/2024/07/how-to-display-ebook-thumbnails-in-nautilus)
